### PR TITLE
Remove CC0 (+BY) references from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,3 @@ Specifically:
    so that others may benefit from the same license you did.
 
  - Do not represent yourself as the original author of re-used material.
-
-For more information on these guidelines, which are sometimes known as
-CC0 (+BY), see [this blog post](http://www.dancohen.org/2013/11/26/cc0-by/) by
-Dan Cohen.


### PR DESCRIPTION
After discussion at Discord's _Scientific Python_ community, the concern of how CC0 (+BY) is represented was raised. It was argued that it would be better to leave CC0 attributions and remove CC0 (+BY) references.